### PR TITLE
apt-get update was missing from Dockerfile resulting in Failed to fetch error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update
 # setup rosdep
 RUN sh -c 'echo "yaml http://packages.dataspeedinc.com/ros/ros-public-'$ROS_DISTRO'.yaml '$ROS_DISTRO'" > /etc/ros/rosdep/sources.list.d/30-dataspeed-public-'$ROS_DISTRO'.list'
 RUN rosdep update
+RUN apt-get update
 RUN apt-get install -y ros-$ROS_DISTRO-dbw-mkz
 RUN apt-get upgrade -y
 # end installing Dataspeed DBW


### PR DESCRIPTION
E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/p/poppler/libpoppler58_0.41.0-0ubuntu1.4_amd64.deb 404 Not Found [IP: ...]

E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/m/mysql-5.7/libmysqlclient-dev_5.7.19-0ubuntu0.16.04.1_amd64.deb 404 Not Found [IP: ...]

E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
The command '/bin/sh -c apt-get install -y ros-$ROS_DISTRO-cv-bridge' returned a non-zero code: 100

Adding apt-get update after rosdep update has solved this issue.